### PR TITLE
feature/RA-50-Mettre-en-place-la-CI-CD-avec-GitHub-Actions

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -1,0 +1,69 @@
+name: CI - Develop Branch PR
+
+on:
+  pull_request:
+    branches:
+      - "develop"
+    paths:
+      - "epic/**"
+    types: [opened, synchronize, reopened]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1 : Checkout du code source
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2 : Configuration de JDK 17
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      # Step 3 : Donner la permission d'exécution au wrapper Gradle
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      #start emulator and run instrumented tests
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Step 4 : Installation des dépendances du projet
+      - name: Download dependencies
+        run: ./gradlew dependencies
+
+      # Step 5 : Exécuter les tests unitaires
+      - name: Run Unit Tests
+        run: ./gradlew test
+
+      # Step 6 : Démarrer l'émulateur et exécuter les tests instrumentés
+      - name: Start emulator and run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          target: google_apis
+          arch: x86_64
+          api-level: 35
+          script: |
+            echo "--- [Waiting for emulator to stabilize...]"
+            adb wait-for-device
+            
+            echo "--- [Unlocking emulator screen...]"
+            adb shell input keyevent 82
+            adb shell wm dismiss-keyguard
+            echo "--- [Building app ...]"
+            ./gradlew build
+            echo "--- [Running instrumented tests ...]"
+            ./gradlew connectedAndroidTest
+
+      # Step 7 : Vérification du statut du job
+      - name: Fail PR on error
+        if: ${{ failure() }}
+        run: exit 1

--- a/.github/workflows/ci-epic.yml
+++ b/.github/workflows/ci-epic.yml
@@ -1,0 +1,41 @@
+name: CI - Epic Branch PR
+
+on:
+  pull_request:
+    branches:
+      - "epic/**"
+    types: [opened, synchronize, reopened]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1 : Checkout du code source
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2 : Configuration de JDK 17
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      # Step 3 : Donner la permission d'exécution au wrapper Gradle
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      # Step 4 : Installation des dépendances du projet
+      - name: Download dependencies
+        run: ./gradlew dependencies
+
+      # Step 5 : Exécuter les tests unitaires et générer le rapport Jacoco
+      - name: Run Unit Tests
+        run: ./gradlew test
+
+      # Step 6 : Vérification du statut du job
+      - name: Fail PR on error
+        if: ${{ failure() }}
+        run: exit 1

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,0 +1,73 @@
+name: CI - Main Branch PR
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "develop/**"
+    types: [opened, synchronize, reopened]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1 : Checkout du code source
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2 : Configuration de JDK 17
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      # Step 3 : Donner la permission d'exécution au wrapper Gradle
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      #start emulator and run instrumented tests
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Step : Récupérer l'historique Git complet pour SonarCloud
+      - name: Fetch full Git history
+        run: git fetch --unshallow
+
+      # Step 4 : Installation des dépendances du projet
+      - name: Download dependencies
+        run: ./gradlew dependencies
+
+      # Step 5 : Exécuter les tests unitaires
+      - name: Run Unit Tests
+        run: ./gradlew test
+
+      # Step 6 : Démarrer l'émulateur et exécuter les tests instrumentés
+      - name: Start emulator and run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          target: google_apis
+          arch: x86_64
+          api-level: 35
+          script: |
+            echo "--- [Waiting for emulator to stabilize...]"
+            adb wait-for-device
+            
+            echo "--- [Unlocking emulator screen...]"
+            adb shell input keyevent 82
+            adb shell wm dismiss-keyguard
+            echo "--- [Building app ...]"
+            ./gradlew build
+            echo "--- [Running instrumented tests ...]"
+            ./gradlew connectedAndroidTest
+
+      # Step 7 : Vérification du statut du job
+      - name: Fail PR on error
+        if: ${{ failure() }}
+        run: exit 1


### PR DESCRIPTION

Mise en place du workflow GitHub Actions pour les differentes PR entre 'develop', 'epic', 'feature', 'main'


  - Ajout du fichier ci-epic.yaml pour exécuter les tests unitaires lors des PR entre les branches 'feature' et la branche 'epic' parent.

  - Ajout du fichier ci-develop.yaml pour exécuter les tests unitaires et instrumentes lors des PR entre les branches 'epic' et la branche 'develop' parent.

  -  Ajout du fichier ci-main.yaml pour exécuter les tests unitaires et instrumentes lors des PR entre la branche 'develop' et la branche 'main' racine.

  - Le workflow comprend la configuration de JDK 17, la configuration de l'emulateur, la gestion des autorisations, l'execution des tests.


Le code Coverage (Jacoco), les quality gates (sonar),et le build de release (CD),  seront ajouter lors des epics propre a ses features. 