### PR TITLE
Feature/RA-49 - Ajouter hilt et mettre en place injection de dependances

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".RebonnteApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/openclassrooms/rebonnte/MainActivity.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/MainActivity.kt
@@ -71,7 +71,9 @@ import com.openclassrooms.rebonnte.ui.aisle.AisleViewModel
 import com.openclassrooms.rebonnte.ui.medicine.MedicineScreen
 import com.openclassrooms.rebonnte.ui.medicine.MedicineViewModel
 import com.openclassrooms.rebonnte.ui.theme.RebonnteTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private lateinit var myBroadcastReceiver: MyBroadcastReceiver

--- a/app/src/main/java/com/openclassrooms/rebonnte/RebonnteApplication.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/RebonnteApplication.kt
@@ -1,0 +1,12 @@
+package com.openclassrooms.rebonnte
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+/**
+ *  This application class is the entry point into the application process used for global application-level
+ *  initialization tasks such as dependency injection setup using Hilt.
+ */
+@HiltAndroidApp
+class RebonnteApplication : Application() {
+}

--- a/app/src/main/java/com/openclassrooms/rebonnte/di/AppModule.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/di/AppModule.kt
@@ -1,0 +1,17 @@
+package com.openclassrooms.rebonnte.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * This class acts as a Dagger Hilt module, responsible for providing dependencies to other parts of the application.
+ * It's installed in the SingletonComponent, ensuring that dependencies provided by this module are created only once
+ * and remain available throughout the application's lifecycle.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+class AppModule {
+
+    //add here all injector provider
+}

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleDetailActivity.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleDetailActivity.kt
@@ -33,7 +33,9 @@ import com.openclassrooms.rebonnte.ui.medicine.Medicine
 import com.openclassrooms.rebonnte.ui.medicine.MedicineDetailActivity
 import com.openclassrooms.rebonnte.ui.medicine.MedicineViewModel
 import com.openclassrooms.rebonnte.ui.theme.RebonnteTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AisleDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-@HiltViewModel
+//@HiltViewModel
 class AisleViewModel : ViewModel() {
     var _aisles = MutableStateFlow<List<Aisle>>(emptyList())
     val aisles: StateFlow<List<Aisle>> get() = _aisles

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
@@ -1,9 +1,10 @@
 package com.openclassrooms.rebonnte.ui.aisle
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-
+@HiltViewModel
 class AisleViewModel : ViewModel() {
     var _aisles = MutableStateFlow<List<Aisle>>(emptyList())
     val aisles: StateFlow<List<Aisle>> get() = _aisles

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineDetailActivity.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineDetailActivity.kt
@@ -37,8 +37,9 @@ import androidx.lifecycle.ViewModelProvider
 import com.openclassrooms.rebonnte.MainActivity
 import com.openclassrooms.rebonnte.ui.history.History
 import com.openclassrooms.rebonnte.ui.theme.RebonnteTheme
+import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
-
+@AndroidEntryPoint
 class MedicineDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Locale
 import java.util.Random
-@HiltViewModel
+//@HiltViewModel
 class MedicineViewModel : ViewModel() {
     var _medicines = MutableStateFlow<MutableList<Medicine>>(mutableListOf())
     val medicines: StateFlow<List<Medicine>> get() = _medicines

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
@@ -2,11 +2,12 @@ package com.openclassrooms.rebonnte.ui.medicine
 
 import androidx.lifecycle.ViewModel
 import com.openclassrooms.rebonnte.ui.aisle.Aisle
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Locale
 import java.util.Random
-
+@HiltViewModel
 class MedicineViewModel : ViewModel() {
     var _medicines = MutableStateFlow<MutableList<Medicine>>(mutableListOf())
     val medicines: StateFlow<List<Medicine>> get() = _medicines


### PR DESCRIPTION
Cette PR ajoute et configure Hilt comme solution d'injection de dépendances dans le projet.

 Changements effectués

-  Ajout des dépendances Hilt dans build.gradle.kts (app) et gestion via libs.versions.toml
-  Ajout du plugin Hilt dans build.gradle.kts (project) et build.gradle.kts (app)
-  Création d'une Application class annotée avec @HiltAndroidApp
-  Ajout de @AndroidEntryPoint sur MainActivity pour permettre l'injection
-  Création du package di avec AppModule (prêt pour la configuration des injections)

Prochaines étapes

- Ajouter les injections dans les classes nécessaires (ViewModel, Repository, etc.)
- Configurer les modules Hilt pour gérer les dépendances spécifiques au projet

Le projet est prêt à utiliser Hilt pour l’injection de dépendances, sans erreur de compilation. 