### PR TITLE
Feature/RA-51 - Ajouter la couverture de test avec jacoco

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,8 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,10 @@ android {
                 "proguard-rules.pro"
             )
         }
+        debug {
+            enableAndroidTestCoverage = true
+            enableUnitTestCoverage = true
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,9 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+
 }
 
 //JACOCO STUFF --------------------

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,23 @@ android {
     namespace = "com.openclassrooms.rebonnte"
     compileSdk = 34
 
+
+
+
+    testCoverage {
+        version = "0.8.8"
+    }
+
+    testOptions {
+        animationsDisabled = true
+        unitTests.isIncludeAndroidResources = true
+    }
+
+
+
+
+
+
     defaultConfig {
         applicationId = "com.openclassrooms.rebonnte"
         minSdk = 24


### PR DESCRIPTION
Cette PR ajoute et configure JaCoCo pour la génération de rapports de couverture de tests dans le projet.

Changements effectués :

 - Ajout de la configuration JaCoCo dans le fichier build.gradle.kts pour générer des rapports de couverture de tests.
 
- Configuration de la génération des rapports en formats HTML et XML pour une visualisation détaillée.
 
- Inclusion des tests unitaires (testDebugUnitTest) et des tests instrumentés (connectedDebugAndroidTest) dans le rapport de couverture.
 
- Exclusion de certaines classes (comme R.class, Hilt_*, et d'autres classes générées) pour une couverture plus précise du code source.

- Vérification et génération des rapports dans le répertoire app/build/reports/jacoco/jacocoTestReport/.