### PR TITLE
Feature/RA-66 - Creation du repository authentification

### DIFF
--- a/app/src/main/java/com/openclassrooms/rebonnte/data/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/data/repository/AuthenticationRepository.kt
@@ -1,7 +1,59 @@
 package com.openclassrooms.rebonnte.data.repository
+
+import com.google.firebase.auth.FirebaseUser
+import com.openclassrooms.rebonnte.data.service.authentication.FirebaseAuthService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
 /**
  * Repository for authentication-related operations.
  * @param authService The service for authentication operations (hilt injected).
  */
-class AuthenticationRepository {
+class AuthenticationRepository @Inject constructor(private val authService: FirebaseAuthService) {
+    /**
+     * Register a new user with the provided email and password.
+     * @param email The user's email.
+     * @param password The user's password.
+     * @return A flow emitting the result of the registration operation.
+     */
+    fun registerUser(email: String, password: String): Flow<Result<FirebaseUser?>> = flow {
+        emit(authService.registerUser(email, password))
+    }
+
+    /**
+     * Sign in a user with the provided email and password.
+     * @param email The user's email.
+     * @param password The user's password.
+     * @return A flow emitting the result of the sign-in operation.
+     */
+    fun signInUser(email: String, password: String): Flow<Result<FirebaseUser?>> = flow {
+        emit(authService.signInUser(email, password))
+    }
+
+    /**
+     * Sign out the current user.
+     * @return A flow emitting the result of the sign-out operation.
+     */
+    fun signOutUser(): Flow<Result<Unit>> = flow {
+        emit(authService.signOutUser())
+    }
+
+    /**
+     * Delete the current user account.
+     * @param user The user to delete.
+     * @return A flow emitting the result of the account deletion operation.
+     */
+    fun deleteUserAccount(user: FirebaseUser): Flow<Result<Unit>> = flow {
+        emit(authService.deleteUserAccount(user))
+    }
+
+    /**
+     * Send a password reset email to the user.
+     * @param email The user's email.
+     * @return A flow emitting the result of the password reset operation.
+     */
+    fun sendPasswordResetEmail(email: String): Flow<Result<Unit>> = flow {
+        emit(authService.sendPasswordResetEmail(email))
+    }
 }

--- a/app/src/main/java/com/openclassrooms/rebonnte/di/AppModule.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.openclassrooms.rebonnte.di
 
+import com.openclassrooms.rebonnte.data.repository.AuthenticationRepository
 import com.openclassrooms.rebonnte.data.service.authentication.FirebaseAuthService
 import dagger.Module
 import dagger.Provides
@@ -25,6 +26,17 @@ class AppModule {
     @Singleton
     fun provideFirebaseAuthService(): FirebaseAuthService {
         return FirebaseAuthService()
+    }
+
+    /**
+     * Provide a singleton instance of Authentication Repository
+     * @param authService The Authentication Service
+     * @return The Authentication Repository
+     */
+    @Provides
+    @Singleton
+    fun provideAuthRepository(authService: FirebaseAuthService): AuthenticationRepository {
+        return AuthenticationRepository(authService)
     }
 
 


### PR DESCRIPTION
Dans cette PR, nous avons créé le repository AuthenticationRepository, qui encapsule le service FirebaseAuthService et expose une interface claire aux ViewModels. 

Le repository offre les fonctionnalités nécessaires pour enregistrer, connecter, déconnecter et supprimer des utilisateurs, ainsi que pour envoyer des emails de réinitialisation de mot de passe.

Changements apportés :

- Création d'une classe AuthenticationRepository dans le package data.repository.

- Chaque méthode du repository appelle le service FirebaseAuthService pour effectuer les opérations d'authentification.

- Les méthodes renvoient un Flow<Result<FirebaseUser?>> pour gérer les opérations asynchrones et les résultats.

- Le repository est injecté dans le ViewModel à l'aide de Dagger Hilt, permettant une gestion des dépendances centralisée.