### PR TITLE
Feature/RA-73 - Ajouter les ecrans de connexion, inscription, et no internet a la navigation

### DIFF
--- a/app/src/main/java/com/openclassrooms/rebonnte/MainActivity.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/MainActivity.kt
@@ -47,34 +47,21 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarColors
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.openclassrooms.rebonnte.data.service.authentication.FirebaseAuthService
-import com.openclassrooms.rebonnte.ui.aisle.AisleScreen
-import com.openclassrooms.rebonnte.ui.aisle.AisleViewModel
-import com.openclassrooms.rebonnte.ui.authentication.LoginScreen
-import com.openclassrooms.rebonnte.ui.authentication.RegisterUserScreen
-import com.openclassrooms.rebonnte.ui.medicine.MedicineScreen
-import com.openclassrooms.rebonnte.ui.medicine.MedicineViewModel
-import com.openclassrooms.rebonnte.ui.noInternet.NoInternetScreen
+import com.openclassrooms.rebonnte.navigation.RebonnteNavHost
+import com.openclassrooms.rebonnte.navigation.ScreensNav
 import com.openclassrooms.rebonnte.ui.theme.RebonnteTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -96,10 +83,8 @@ class MainActivity : ComponentActivity() {
             //debug of auth service injection
             Log.d("authDebug", "Connected user: ${authService.getCurrentConnectedUser()!=null} ")
 
-           // MyApp()
-           // LoginScreen(onNavigateToMainScreen = {  },onNavigateToRegisterScreen = {  })
-           // RegisterUserScreen(onNavigateToMainScreen = {  },onNavigateToSignInScreen = {  })
-            NoInternetScreen()
+            MyApp()
+
 
         }
 
@@ -145,12 +130,11 @@ class MainActivity : ComponentActivity() {
 
 //todo - Extract navigation logic outside compo
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyApp() {
     val navController = rememberNavController()
-    val medicineViewModel: MedicineViewModel = viewModel()
-    val aisleViewModel: AisleViewModel = viewModel()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val route = navBackStackEntry?.destination?.route
 
@@ -184,21 +168,21 @@ fun MyApp() {
                                         ) {
                                             DropdownMenuItem(
                                                 onClick = {
-                                                    medicineViewModel.sortByNone()
+                   //                                 medicineViewModel.sortByNone()
                                                     expanded = false
                                                 },
                                                 text = { Text("Sort by None") }
                                             )
                                             DropdownMenuItem(
                                                 onClick = {
-                                                    medicineViewModel.sortByName()
+                 //                                   medicineViewModel.sortByName()
                                                     expanded = false
                                                 },
                                                 text = { Text("Sort by Name") }
                                             )
                                             DropdownMenuItem(
                                                 onClick = {
-                                                    medicineViewModel.sortByStock()
+               //                                     medicineViewModel.sortByStock()
                                                     expanded = false
                                                 },
                                                 text = { Text("Sort by Stock") }
@@ -213,7 +197,7 @@ fun MyApp() {
                         EmbeddedSearchBar(
                             query = searchQuery,
                             onQueryChange = {
-                                medicineViewModel.filterByName(it)
+           //                     medicineViewModel.filterByName(it)
                                 searchQuery = it
                             },
                             isSearchActive = isSearchActive,
@@ -242,23 +226,19 @@ fun MyApp() {
             floatingActionButton = {
                 FloatingActionButton(onClick = {
                     if (route == "medicine") {
-                        medicineViewModel.addRandomMedicine(aisleViewModel.aisles.value)
+     //                   medicineViewModel.addRandomMedicine(aisleViewModel.aisles.value)
                     } else if (route == "aisle") {
-                        aisleViewModel.addRandomAisle()
+     //                   aisleViewModel.addRandomAisle()
                     }
                 }) {
                     Icon(Icons.Default.Add, contentDescription = "Add")
                 }
             }
         ) {
-            NavHost(
-                modifier = Modifier.padding(it),
-                navController = navController,
-                startDestination = "aisle"
-            ) {
-                composable("aisle") { AisleScreen(aisleViewModel) }
-                composable("medicine") { MedicineScreen(medicineViewModel) }
-            }
+            RebonnteNavHost(
+                navHostController = navController,
+                startDestination = ScreensNav.Main.route,
+            )
         }
     }
 }

--- a/app/src/main/java/com/openclassrooms/rebonnte/RebonnteApplication.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/RebonnteApplication.kt
@@ -1,6 +1,7 @@
 package com.openclassrooms.rebonnte
 
 import android.app.Application
+import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
 
 /**
@@ -9,4 +10,11 @@ import dagger.hilt.android.HiltAndroidApp
  */
 @HiltAndroidApp
 class RebonnteApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // Initialize Firebase
+        FirebaseApp.initializeApp(this)
+
+
+    }
 }

--- a/app/src/main/java/com/openclassrooms/rebonnte/navigation/RebonnteNavHost.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/navigation/RebonnteNavHost.kt
@@ -76,7 +76,7 @@ fun RebonnteNavHost (
         //Login screen
         composable(route = ScreensNav.SignIn.route){
             LoginScreen(
-                onNavigateToAisleScreen = {
+                onNavigateToMainScreen = {
                     navHostController.navigate(ScreensNav.Main.route) {
                         //clean the nav backstack
                         popUpTo(0)
@@ -100,9 +100,8 @@ fun RebonnteNavHost (
 
             ){
             RegisterUserScreen(
-                onNavigateToAisleScreen = { navHostController.navigate(ScreensNav.Main.route) },
-                onNavigateToLoginScreen = { navHostController.navigate(ScreensNav.SignIn.route) },
-                onBackClick = { navHostController.popBackStack() }
+                onNavigateToMainScreen = { navHostController.navigate(ScreensNav.Main.route) },
+                onNavigateToLoginScreen = { navHostController.navigate(ScreensNav.SignIn.route) }
             )
         }
 

--- a/app/src/main/java/com/openclassrooms/rebonnte/navigation/RebonnteNavHost.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/navigation/RebonnteNavHost.kt
@@ -1,13 +1,118 @@
 package com.openclassrooms.rebonnte.navigation
 
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.openclassrooms.rebonnte.ui.MainScreen
+import com.openclassrooms.rebonnte.ui.authentication.LoginScreen
+import com.openclassrooms.rebonnte.ui.authentication.RegisterUserScreen
+import com.openclassrooms.rebonnte.ui.noInternet.NoInternetScreen
 
 @Composable
 fun RebonnteNavHost (
     navHostController: NavHostController,
     startDestination: String
 ) {
+    NavHost(
+        navController = navHostController,
+        startDestination = startDestination,
+    ) {
 
+        //Main screen
+        composable(route = ScreensNav.Main.route){
+            //todo main screen conteneur
+            MainScreen(
+                onLogOutAction = {
+                    navHostController.navigate(ScreensNav.SignIn.route) {
+                        //clean the nav backstack
+                        popUpTo(0)
+                        launchSingleTop = true
+                        restoreState = false
+                    }
+                },
+                onAddMedicineAction = {
+                    navHostController.navigate(ScreensNav.AddMedicine.route)
+                },
+                onMedicineClicked = {
+                    navHostController.navigate(ScreensNav.MedicineDetails.route)
+                },
+                onAisleClicked = {
+                    navHostController.navigate(ScreensNav.AisleDetails.route)
+                }
+
+            )
+        }
+
+
+        //Medicine details screen
+        composable(route = ScreensNav.MedicineDetails.route,
+            arguments = ScreensNav.MedicineDetails.navArguments
+        ){ backStackEntry ->
+            val medicineId = backStackEntry.arguments?.getString("medicineId")
+                ?: throw IllegalArgumentException("Medicine ID is required")
+           // MedicineDetailsScreen(medicineId = medicineId)
+        }
+
+        //Aisle Details screen
+        composable(route = ScreensNav.AisleDetails.route,
+            arguments = ScreensNav.AisleDetails.navArguments
+        ){backStackEntry ->
+            val aisleId = backStackEntry.arguments?.getString("aisleId")
+                ?: throw IllegalArgumentException("Aisle ID is required")
+          //  AisleDetailsScreen(aisleId = aisleId))
+        }
+
+        //Add medicine screen
+        composable(route = ScreensNav.AddMedicine.route){
+          //  AddMedicineScreen(onBackClick = { navHostController.popBackStack() })
+        }
+
+
+        //Login screen
+        composable(route = ScreensNav.SignIn.route){
+            LoginScreen(
+                onNavigateToAisleScreen = {
+                    navHostController.navigate(ScreensNav.Main.route) {
+                        //clean the nav backstack
+                        popUpTo(0)
+                        launchSingleTop = true
+                        restoreState = false
+                    }
+                },
+                onNavigateToRegisterScreen = { navHostController.navigate(ScreensNav.SignUp.route) }
+            )
+        }
+
+        //Register screen
+        composable(route = ScreensNav.SignUp.route,
+            enterTransition = {
+                slideInHorizontally(initialOffsetX = { fullWidth -> fullWidth }) + fadeIn()
+            },
+            exitTransition = {
+                slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut()
+            }
+
+
+            ){
+            RegisterUserScreen(
+                onNavigateToAisleScreen = { navHostController.navigate(ScreensNav.Main.route) },
+                onNavigateToLoginScreen = { navHostController.navigate(ScreensNav.SignIn.route) },
+                onBackClick = { navHostController.popBackStack() }
+            )
+        }
+
+        //No internet screen
+        composable(route = ScreensNav.NoInternet.route){
+            NoInternetScreen()
+        }
+
+
+
+    }
 
 }

--- a/app/src/main/java/com/openclassrooms/rebonnte/navigation/ScreensNav.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/navigation/ScreensNav.kt
@@ -14,4 +14,16 @@ val navArguments: List<NamedNavArgument> = emptyList()
 
     data object NoInternet : ScreensNav("noInternet")
 
+
+    data object MedicineDetails : ScreensNav("medicineDetails/{medicineId}"){
+        fun createRoute(medicineId: String) = "medicineDetails/$medicineId"
+    }
+
+    data object AisleDetails : ScreensNav("aisleDetails/{aisleId}"){
+        fun createRoute(aisleId: String) = "aisleDetails/$aisleId"
+    }
+
+    data object AddMedicine : ScreensNav("addMedicine")
+
+
 }

--- a/app/src/main/java/com/openclassrooms/rebonnte/navigation/ScreensNav.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/navigation/ScreensNav.kt
@@ -1,0 +1,17 @@
+package com.openclassrooms.rebonnte.navigation
+
+import androidx.navigation.NamedNavArgument
+
+sealed class ScreensNav( val route: String,
+val navArguments: List<NamedNavArgument> = emptyList()
+) {
+
+    data object Main : ScreensNav("main")
+
+    data object SignIn : ScreensNav("signIn")
+
+    data object SignUp : ScreensNav("signUp")
+
+    data object NoInternet : ScreensNav("noInternet")
+
+}

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/MainScreen.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/MainScreen.kt
@@ -1,0 +1,23 @@
+package com.openclassrooms.rebonnte.ui
+
+import androidx.compose.runtime.Composable
+import com.openclassrooms.rebonnte.ui.medicine.Medicine
+
+/**
+ * Main screen composable function.
+ *  - Manages the inner navigation graph for the Aisle and Medicine screens.
+ *  - Manages the bottom navigation bar.
+ */
+@Composable
+fun MainScreen(
+    onLogOutAction: () -> Unit,
+    onAddMedicineAction: () -> Unit,
+    onMedicineClicked: (Medicine) -> Unit,
+    onAisleClicked: (String) -> Unit
+) {
+
+    //todo main screen contentment for Aisle and Medicine screens
+
+
+
+}

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleScreen.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleScreen.kt
@@ -21,9 +21,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun AisleScreen(viewModel: AisleViewModel) {
+fun AisleScreen(
+    viewModel: AisleViewModel = hiltViewModel()
+) {
     val aisles by viewModel.aisles.collectAsState(initial = emptyList())
     val context = LocalContext.current
 

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/aisle/AisleViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-//@HiltViewModel
-class AisleViewModel : ViewModel() {
+import javax.inject.Inject
+
+@HiltViewModel
+class AisleViewModel @Inject constructor() : ViewModel() {
     var _aisles = MutableStateFlow<List<Aisle>>(emptyList())
     val aisles: StateFlow<List<Aisle>> get() = _aisles
 

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/authentication/RegisterUserScreen.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/authentication/RegisterUserScreen.kt
@@ -56,8 +56,8 @@ import com.openclassrooms.rebonnte.ui.theme.Rebonnte_green2
  **/
 @Composable
 fun RegisterUserScreen(viewModel: AuthenticationViewModel = hiltViewModel(),
-                       onNavigateToSignInScreen: () -> Unit,
-                       onNavigateToMainScreen: () -> Unit
+                       onNavigateToMainScreen: () -> Unit,
+                       onNavigateToLoginScreen: () -> Unit
 ) {
 
     //Register user result from the viewmodel
@@ -229,7 +229,7 @@ fun RegisterUserScreen(viewModel: AuthenticationViewModel = hiltViewModel(),
 
             Row {
                 Text("Already have an account? ", color = Color.Gray)
-                TextButton(onClick = { onNavigateToSignInScreen() }) {
+                TextButton(onClick = { onNavigateToLoginScreen() }) {
                     Text("Sign In!", fontWeight = FontWeight.Bold, color = Rebonnte_green1)
                 }
             }

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/Medicine.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/Medicine.kt
@@ -3,6 +3,7 @@ package com.openclassrooms.rebonnte.ui.medicine
 import com.openclassrooms.rebonnte.ui.history.History
 
 data class Medicine(
+    val id: String,
     var name: String,
     var stock: Int,
     var nameAisle: String,

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineScreen.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineScreen.kt
@@ -16,11 +16,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun MedicineScreen(viewModel: MedicineViewModel = viewModel()) {
+fun MedicineScreen(
+    viewModel: MedicineViewModel = hiltViewModel(),
+    onBackClick: () -> Unit
+    ) {
     val medicines by viewModel.medicines.collectAsState(initial = emptyList())
     val context = LocalContext.current
 

--- a/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
+++ b/app/src/main/java/com/openclassrooms/rebonnte/ui/medicine/MedicineViewModel.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Locale
 import java.util.Random
-//@HiltViewModel
-class MedicineViewModel : ViewModel() {
+import javax.inject.Inject
+
+@HiltViewModel
+class MedicineViewModel @Inject constructor() : ViewModel() {
     var _medicines = MutableStateFlow<MutableList<Medicine>>(mutableListOf())
     val medicines: StateFlow<List<Medicine>> get() = _medicines
 
@@ -20,10 +22,11 @@ class MedicineViewModel : ViewModel() {
         val currentMedicines = ArrayList(medicines.value)
         currentMedicines.add(
             Medicine(
-                "Medicine " + (currentMedicines.size + 1),
-                Random().nextInt(100),
-                aisles[Random().nextInt(aisles.size)].name,
-                emptyList()
+                id = "Medicine " + (currentMedicines.size + 1),
+                name = Random().nextInt(100).toString(),
+                stock = Random().nextInt(100),
+                nameAisle = aisles[Random().nextInt(aisles.size)].name,
+                histories = emptyList()
             )
         )
         _medicines.value = currentMedicines


### PR DESCRIPTION
Cette PR introduit un Navigation Host centralisé pour gérer la navigation dans l’application, accompagné d'une refonte de la structure de navigation entre les ecran. 

Elle inclut également des ajustements du MainActivity et d’autres adaptations mineures pour assurer une transition fluide vers la nouvelle architecture de navigation.

Changements apportés:

-  Ajout d’un NavHost pour une gestion centralisée de la navigation.

-  Création d’une classe sealed pour les routes afin de structurer les différentes destinations de l’application.

-  Mise à jour de MainActivity pour intégrer la nouvelle navigation et assurer le bon fonctionnement du NavHost.

-  Modifications mineures dans le code pour adapter temporairement certaines parties à la nouvelle navigation.