### PR TITLE
Feature/RA-37 - Mettre en place la cd pour déployer l'apk sur firebase app distribution

### DIFF
--- a/.github/workflows/ci-epic.yml
+++ b/.github/workflows/ci-epic.yml
@@ -38,34 +38,33 @@ jobs:
       - name: Download dependencies
         run: ./gradlew dependencies
           
-          # Step  : Lancer les tests unitaire  + jacocoreport 
-               - name: Run Tests/generate Jacoco cover report
-               env:
-                 SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-               uses: reactivecircus/android-emulator-runner@v2
-               with:
-                 target: google_apis
-                 arch: x86_64
-                 api-level: 35
-                 script: |
-                   echo "--- [Waiting for emulator to stabilize...]"
-                   #sleep 30 
-                   adb wait-for-device
-                   
-                   echo "--- [Unlocking emulator screen...]"
-                   adb shell input keyevent 82
-                   adb shell wm dismiss-keyguard
-                   
-                   echo "--- [Lint debug]"
-                   ./gradlew lintDebug
-                   
-                   echo "--- [Generating Jacoco report...]"
-                   ./gradlew jacocoReport
-                   
-                   echo "--- [Checking if Jacoco report exists...]"
-                   ls app/build/reports/jacoco/jacocoTestReport
-                   cat app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml || echo " [X] - Jacoco report not found"
-                   
+# Step  : Lancer les tests unitaire  + jacocoreport
+      - name: Run Tests/generate Jacoco cover report
+        env:
+         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+         target: google_apis
+         arch: x86_64
+         api-level: 35
+         script: |
+           echo "--- [Waiting for emulator to stabilize...]"
+           #sleep 30 
+           adb wait-for-device
+           
+           echo "--- [Unlocking emulator screen...]"
+           adb shell input keyevent 82
+           adb shell wm dismiss-keyguard
+           
+           echo "--- [Lint debug]"
+           ./gradlew lintDebug
+           
+           echo "--- [Generating Jacoco report...]"
+           ./gradlew jacocoReport
+           
+           echo "--- [Checking if Jacoco report exists...]"
+           ls app/build/reports/jacoco/jacocoTestReport
+           cat app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml || echo " [X] - Jacoco report not found"
 
       # Step 6 : Vérification du statut du job
       - name: Fail PR on error

--- a/.github/workflows/ci-epic.yml
+++ b/.github/workflows/ci-epic.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "epic/**"
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 jobs:
   unit-tests:
@@ -27,44 +27,17 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # Step 4 : Reconstruire le fichier keystore à partir du secret
-      - name: Decode keystore file
-        run: |
-          echo "${{ secrets.KEYSTORE_FILE_BASE64 }}" | base64 -d > app/rebonnte-release-key.jks
-          ls -la app/ 
-
-
       # Step 4 : Installation des dépendances du projet
       - name: Download dependencies
         run: ./gradlew dependencies
           
-# Step  : Lancer les tests unitaire  + jacocoreport
-      - name: Run Tests/generate Jacoco cover report
-        env:
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-         target: google_apis
-         arch: x86_64
-         api-level: 35
-         script: |
-           echo "--- [Waiting for emulator to stabilize...]"
-           #sleep 30 
-           adb wait-for-device
-           
-           echo "--- [Unlocking emulator screen...]"
-           adb shell input keyevent 82
-           adb shell wm dismiss-keyguard
-           
-           echo "--- [Lint debug]"
-           ./gradlew lintDebug
-           
-           echo "--- [Generating Jacoco report...]"
-           ./gradlew jacocoReport
-           
-           echo "--- [Checking if Jacoco report exists...]"
-           ls app/build/reports/jacoco/jacocoTestReport
-           cat app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml || echo " [X] - Jacoco report not found"
+      # Step 5 : Exécution des tests unitaires et analyse lint
+      - name: Run Unit Tests & Lint
+        run: |
+          echo "--- [Running Lint...]"
+          ./gradlew lintDebug
+          echo "--- [Running Unit Tests...]"
+          ./gradlew testDebugUnitTest
 
       # Step 6 : Vérification du statut du job
       - name: Fail PR on error

--- a/.github/workflows/ci-epic.yml
+++ b/.github/workflows/ci-epic.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
+      # Step 3.5 : Reconstruire le fichier keystore à partir du secret
+      - name: Decode keystore file
+        run: |
+          echo "${{ secrets.KEYSTORE_FILE_BASE64 }}" | base64 -d > app/rebonnte-release-key.jks
+          ls -la app/ 
+
       # Step 4 : Installation des dépendances du projet
       - name: Download dependencies
         run: ./gradlew dependencies

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -8,7 +8,7 @@ on:
 
 
 jobs:
-  unit-tests:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -100,3 +100,27 @@ jobs:
       - name: Clearance PR
         if: ${{ failure() }}
         run: echo "Build ou analyse de qualité échouée, PR bloquée."
+
+  # Step  : firebase deploy
+  deploy:
+    needs: build
+    if: github.event_name == 'pull_request' && github.ref == 'refs/heads/main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download APK Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-apk
+          path: app/build/outputs/apk/release/
+
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.1
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          #serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: testers
+          file: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
Cette PR met en place l'intégration continue pour déployer automatiquement l'APK de l'application sur Firebase App Distribution à chaque fois qu'une modification est fusionnée dans la branche main.

Changements principaux :

Ajout d'un workflow GitHub Actions pour construire, tester et déployer l'APK.
Intégration de Firebase App Distribution via GitHub Actions, permettant de distribuer l'APK aux testeurs automatiquement après chaque build réussi.

Configuration des secrets nécessaires (FIREBASE_APP_ID, FIREBASE_TOKEN) dans GitHub pour sécuriser l'accès au service de Firebase.


Objectif :

Automatiser le processus de déploiement pour faciliter la distribution des versions testables aux testeurs via Firebase.